### PR TITLE
feat(options): add the option to disable health checks at startup

### DIFF
--- a/helpers/healthCheck.js
+++ b/helpers/healthCheck.js
@@ -7,7 +7,7 @@ const dnsPromises = require('dns').promises;
 const CHECK_NODES_INTERVAL = 60 * 5 * 1000; // Update active nodes every 5 minutes
 const HEIGHT_EPSILON = 5; // Used to group nodes by height and choose synced
 
-module.exports = (nodes) => {
+module.exports = (nodes, checkHealthAtStartup = true) => {
 
 	isCheckingNodes = false;
 	nodesList = nodes;
@@ -16,29 +16,32 @@ module.exports = (nodes) => {
 
 	/**
 		* Updates active nodes. If nodes are already updating, returns Promise of previous call
-    * @returns {Promise} Call changeNodes().then to do something when update complete
-  	*/
-	function changeNodes (isPlannedUpdate = false) {
+		* @returns {Promise} Call changeNodes().then to do something when update complete
+		*/
+	function changeNodes(isPlannedUpdate = false) {
 		if (!isCheckingNodes) {
 			changeNodesPromise = new Promise(async (resolve) => {
 				if (!isPlannedUpdate) {
 					logger.warn('[ADAMANT js-api] Health check: Forcing to update active nodes…');
 				}
-				await checkNodes(isPlannedUpdate? false : true)
+				await checkNodes(isPlannedUpdate ? false : true)
 				resolve(true)
 			});
 		}
 		return changeNodesPromise
 	}
 
-	changeNodes(true)
-	setInterval(() => { changeNodes(true)	}, CHECK_NODES_INTERVAL);
+
+	if (checkHealthAtStartup) {
+		changeNodes(true)
+		setInterval(() => { changeNodes(true) }, CHECK_NODES_INTERVAL);
+	}
 
 	return {
 
 		/**
-     * @returns {string} Current active node, f. e. http://88.198.156.44:36666
-     */
+		 * @returns {string} Current active node, f. e. http://88.198.156.44:36666
+		 */
 		node: () => {
 			return activeNode;
 		},
@@ -145,10 +148,10 @@ async function checkNodes(forceChangeActiveNode) {
 				this.liveNodes.sort((a, b) => a.ping - b.ping);
 
 				if (forceChangeActiveNode && biggestGroup.length > 1 && this.activeNode === biggestGroup[0].node)
-					this.activeNode = biggestGroup[validator.getRandomIntInclusive(1, biggestGroup.length-1)].node // Use random node from which are synced
+					this.activeNode = biggestGroup[validator.getRandomIntInclusive(1, biggestGroup.length - 1)].node // Use random node from which are synced
 				else
 					this.activeNode = biggestGroup[0].node; // Use node with minimum ping among which are synced
-			
+
 			}
 			socket.reviseConnection(this.liveNodes);
 			let unavailableCount = this.nodesList.length - this.liveNodes.length;
@@ -159,7 +162,7 @@ async function checkNodes(forceChangeActiveNode) {
 			if (outOfSyncCount)
 				nodesInfoString += `, ${outOfSyncCount} nodes are not synced`
 			logger.log(`[ADAMANT js-api] Health check: Found ${supportedCount} supported and synced nodes${nodesInfoString}. Active node is ${this.activeNode}.`);
-			
+
 		}
 
 	} catch (e) {

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const logger = require('./helpers/logger');
 module.exports = (params, log) => {
 	log = log || console;
 	logger.initLogger(params.logLevel, log);
-	const nodeManager = healthCheck(params.node);
+	const nodeManager = healthCheck(params.node, params.checkHealthAtStartup);
 
 	return {
 		get: get(nodeManager),


### PR DESCRIPTION
Sometimes the library can be used for one time requests, so there is no need to check health every 5 minutes that blocks script termination. For example in  the [Command Line Interface](https://github.com/Adamant-im/adamant-console)