### PR TITLE
feat: add setStartupCallback method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,7 @@ module.exports = (params, customLogger, checkHealthAtStartupCallback) => {
     sendMessage: sendMessage(nodeManager),
     newDelegate: newDelegate(nodeManager),
     voteForDelegate: voteForDelegate(nodeManager),
+    setStartupCallback: nodeManager.setStartupCallback,
     decodeMsg,
     eth,
     dash,


### PR DESCRIPTION
Since the creation of the api instance is delegated in a file separate from the initialization, it is good to have a setStartupCallback that can be called from the init.js file that imports api.js

```js
// index.js
const api = require('./api.js')

api.setStartupCallback(() => console.log('API is ready to use!'))
```
