### PR TITLE
feat: add checkNodeTimeout param

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -1,5 +1,4 @@
 module.exports = {
-
   epochTime: new Date(Date.UTC(2017, 8, 2, 17, 0, 0, 0)),
   fees: {
     send: 50000000,
@@ -27,6 +26,7 @@ module.exports = {
     STATE: 9,
   },
   maxVotesPerTransaction: 33,
+  HEALTH_CHECK_TIMEOUT: 4000, // 4 seconds
   SAT: 100000000,
   RE_HEX: /^[a-fA-F0-9]+$/,
   RE_BASE64: /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$/,
@@ -42,5 +42,4 @@ module.exports = {
 
   RE_HTTP_URL: /^https?:\/\/(.*)$/,
   RE_IP: /(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}/,
-
 };

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ module.exports = (params, customLogger, checkHealthAtStartupCallback) => {
   const nodeManager = healthCheck(
       params.node,
       params.checkHealthAtStartup,
-      params.checkHealthTimeout,
+      params.checkNodeTimeout,
       checkHealthAtStartupCallback,
   );
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ const keys = require('./helpers/keys');
 
 /**
  * Create new API instance
- * @param {{ node: string, checkHealthAtStartup: boolean, logLevel: string}} params
+ * @param {{ node: string, checkHealthAtStartup: boolean, logLevel: string, checkHealthTimeout: number}} params
  * @param {{ error: function, warn: function, info: function, log: function }?} customLogger
  * @param {function?} checkHealthAtStartupCallback callback which is called after the first health check or
  * just at startup when params.checkHealthAtStartup is passed
@@ -38,6 +38,7 @@ module.exports = (params, customLogger, checkHealthAtStartupCallback) => {
   const nodeManager = healthCheck(
       params.node,
       params.checkHealthAtStartup,
+      params.checkHealthTimeout,
       checkHealthAtStartupCallback,
   );
 


### PR DESCRIPTION
set `checkNodeTimeout` in options in ms (to set timeout for checking a node status obviously)

```js
const api = require('adamant-api')({
  node: nodesList,
  logLevel: 'info',
  checkNodeTimeout: 10000 // 10 seconds. default is 4s 
});
```