### PR TITLE
fix(typescript): include declaration modules in npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,10 @@
   "main": "dist/index.js",
   "src": "src/index.ts",
   "types": "dist/index.d.ts",
-  "files": ["dist/"],
+  "files": [
+    "dist/",
+    "types/"
+  ],
   "scripts": {
     "test": "jest",
     "lint": "gts lint",


### PR DESCRIPTION
this PR fixes the following error when using the library as a dependency
```
Could not find a declaration file for module 'coininfo'.
/// <reference path="../../types/coininfo.d.ts" />
```