### PR TITLE
v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## [2.3.0] - 2024-03-01
+
+### Added
+
+- `transformTransactionQuery` function:
+
+  ```ts
+  const transformed = transformTransactionQuery({
+    fromHeight: 7585271,
+    and: {
+      toHeight: 7586280,
+    },
+    or: {
+      senderId: 'U18132012621449491414',
+    },
+  });
+
+  /**
+   * {
+   *   and:fromHeight: 7585271,
+   *   and:toHeight: 7586280,
+   *   or:senderId: 'U18132012621449491414'
+   * }
+   */
+  console.log(transformed);
+  ```
+
+### Fixed
+
+- TypeScript: `id` should have `string` type in the methods: `api.getTransaction()`, `api.getQueuedTransaction()`, `api.getUnconfirmedTransaction()`
+
+- Global installation of packages that use `adamant-api` as its dependency
+
+- Transaction query methods:
+
+  ```ts
+  const blocks = await api.getTransactions({
+    fromHeight: 7585271,
+    and: {
+      toHeight: 7586280,
+    },
+    or: {
+      senderId: 'U18132012621449491414',
+    },
+  });
+  ```
+
 ## [2.2.0] - 2023-12-01
 
 ## Added
@@ -12,11 +59,13 @@
   function isAdmPublicKey(publicKey: unknown): publicKey is string;
   function isAdmVoteForPublicKey(publicKey: unknown): publicKey is string;
   function isAdmVoteForAddress(address: unknown): boolean;
-  function isAdmVoteForDelegateName(delegateName: unknown): delegateName is string;
+  function isAdmVoteForDelegateName(
+    delegateName: unknown
+  ): delegateName is string;
   function validateMessage(
     message: string,
     messageType: MessageType = MessageType.Chat
-  ): { success: false, error: string } | { success: true };
+  ): {success: false; error: string} | {success: true};
   function isDelegateName(name: unknown): name is string;
   function admToSats(amount: number): number;
   ```
@@ -28,11 +77,13 @@
 - `api.initSocket()` now accepts an instance of `WebSocketClient` as an argument:
 
   ```js
-  const socket = new WebSocketClient({ /* ... */ })
+  const socket = new WebSocketClient({
+    /* ... */
+  });
 
-  api.initSocket(socket)
+  api.initSocket(socket);
   // instead of
-  api.socket = socket
+  api.socket = socket;
   ```
 
 - Improved the `encodeMessage()` and `decodeMessage()` functions to accept public keys as Uint8Array or Buffer
@@ -62,7 +113,7 @@
   For example, you can now use `'log'` instead of `LogLevel.Log` in TypeScript:
 
   ```ts
-  const api = new AdamantApi({ /* ... */ logLevel: 'log' })
+  const api = new AdamantApi({/* ... */ logLevel: 'log'});
   ```
 
 - TypeScript: Added missing declaration modules to npm that led to the error:
@@ -95,7 +146,7 @@
 
   ```js
   // before
-  const block = await api.get('blocks/get', { id });
+  const block = await api.get('blocks/get', {id});
 
   // after
   const block = await api.getBlock(id);
@@ -104,17 +155,16 @@
   and `post()` method:
 
   ```js
-  await api.post('transactions/process', { transaction });
+  await api.post('transactions/process', {transaction});
   ```
-
 
 - **getTransactionId()** method
 
   Pass signed transaction with signature to get a transaction id as a string:
 
   ```js
-  import {getTransactionId} from 'adamant-api'
-  const id = getTransactionId(signedTransaction)
+  import {getTransactionId} from 'adamant-api';
+  const id = getTransactionId(signedTransaction);
   ```
 
   _See [documentation](https://github.com/Adamant-im/adamant-api-jsclient/wiki/Calculating-transaction-id) for more information._
@@ -136,9 +186,13 @@
   Now you will create new instances of `adamant-api` using keyword `new`:
 
   ```js
-  import { AdamantApi } from 'adamant-api';
+  import {AdamantApi} from 'adamant-api';
 
-  const api = new AdamantApi({ nodes: [/* ... */] });
+  const api = new AdamantApi({
+    nodes: [
+      /* ... */
+    ],
+  });
   ```
 
 - **Socket Initialization**
@@ -157,7 +211,7 @@
   });
 
   // after
-  api.initSocket({ admAddress: 'U1234..' });
+  api.initSocket({admAddress: 'U1234..'});
 
   api.socket.on((transaction: AnyTransaction) => {
     // ...
@@ -168,29 +222,34 @@
 
   ```ts
   // socket.ts
-  import { WebSocketClient, TransactionType } from 'adamant-api';
+  import {WebSocketClient, TransactionType} from 'adamant-api';
 
-  const socket = new WebSocketClient({ admAddress: 'U1234..' });
+  const socket = new WebSocketClient({admAddress: 'U1234..'});
 
-  socket.on([TransactionType.CHAT_MESSAGE, TransactionType.SEND], (transaction) => {
-    // handle chat messages and transfer tokens transactions
-  });
+  socket.on(
+    [TransactionType.CHAT_MESSAGE, TransactionType.SEND],
+    transaction => {
+      // handle chat messages and transfer tokens transactions
+    }
+  );
 
-  socket.on(TransactionType.VOTE, (transaction) => {
+  socket.on(TransactionType.VOTE, transaction => {
     // handle vote for delegate transaction
   });
 
-  export { socket };
+  export {socket};
   ```
 
   ```ts
   // api.ts
-  import { AdamantApi } from 'adamant-api';
-  import { socket } from './socket';
+  import {AdamantApi} from 'adamant-api';
+  import {socket} from './socket';
 
   export const api = new AdamantApi({
     socket,
-    nodes: [/* ... */],
+    nodes: [
+      /* ... */
+    ],
   });
   ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [2.2.0] - 2023-12-01
+
+## Added
+
+- Export validator utils:
+
+  ```ts
+  function isPassphrase(passphrase: unknown): passphrase is string;
+  function isAdmAddress(address: unknown): address is AdamantAddress;
+  function isAdmPublicKey(publicKey: unknown): publicKey is string;
+  function isAdmVoteForPublicKey(publicKey: unknown): publicKey is string;
+  function isAdmVoteForAddress(address: unknown): boolean;
+  function isAdmVoteForDelegateName(delegateName: unknown): delegateName is string;
+  function validateMessage(
+    message: string,
+    messageType: MessageType = MessageType.Chat
+  ): { success: false, error: string } | { success: true };
+  function isDelegateName(name: unknown): name is string;
+  function admToSats(amount: number): number;
+  ```
+
 ## [2.1.0] - 2023-11-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adamant-api",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "JavaScript API library for the ADAMANT Blockchain",
   "keywords": [
     "adm",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adamant-api",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "JavaScript API library for the ADAMANT Blockchain",
   "keywords": [
     "adm",
@@ -47,7 +47,6 @@
   "scripts": {
     "test": "jest",
     "lint": "gts lint",
-    "preinstall": "npx only-allow pnpm",
     "prepare": "husky install",
     "clean": "gts clean",
     "compile": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adamant-api",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "JavaScript API library for the ADAMANT Blockchain",
   "keywords": [
     "adm",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -785,7 +785,7 @@ export class AdamantApi extends NodeManager {
    * Get transaction by ID
    */
   async getTransaction(
-    id: number,
+    id: string,
     options?: TransactionQuery<TransactionsOptions>
   ) {
     return this.get<GetTransactionByIdResponseDto>('transactions/get', {
@@ -813,7 +813,7 @@ export class AdamantApi extends NodeManager {
   /**
    * Get queued transaction by ID
    */
-  async getQueuedTransaction(id: number) {
+  async getQueuedTransaction(id: string) {
     return this.get<GetQueuedTransactionsResponseDto>(
       'transactions/queued/get',
       {id}
@@ -832,7 +832,7 @@ export class AdamantApi extends NodeManager {
   /**
    * Get unconfirmed transaction by ID
    */
-  async getUnconfirmedTransaction(id: number) {
+  async getUnconfirmedTransaction(id: string) {
     return this.get<GetUnconfirmedTransactionByIdResponseDto>(
       'transactions/unconfirmed/get',
       {id}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -73,7 +73,11 @@ import {
   createVoteTransaction,
 } from '../helpers/transactions';
 import {encodeMessage} from '../helpers/encryptor';
-import {VoteDirection, parseVote} from './votes';
+import {
+  type VoteDirection,
+  transformTransactionQuery,
+  parseVote,
+} from './utils';
 
 export type AdamantAddress = `U${string}`;
 
@@ -99,9 +103,9 @@ export type AddressOrPublicKeyObject = AddressObject | PublicKeyObject;
  */
 export type UsernameOrPublicKeyObject = UsernameObject | PublicKeyObject;
 
-export type TransactionQuery<T extends {}> = T & {
-  or: T;
-  and: T;
+export type TransactionQuery<T extends object> = Partial<T> & {
+  or?: Partial<T>;
+  and?: Partial<T>;
 };
 
 export interface GetBlocksOptions {
@@ -571,7 +575,10 @@ export class AdamantApi extends NodeManager {
     address: string,
     options?: TransactionQuery<ChatroomsOptions>
   ) {
-    return this.get<GetChatRoomsResponseDto>(`chatrooms/${address}`, options);
+    return this.get<GetChatRoomsResponseDto>(
+      `chatrooms/${address}`,
+      transformTransactionQuery(options)
+    );
   }
 
   /**
@@ -584,7 +591,7 @@ export class AdamantApi extends NodeManager {
   ) {
     return this.get<GetChatMessagesResponseDto>(
       `chatrooms/${address1}/${address2}`,
-      query
+      transformTransactionQuery(query)
     );
   }
 
@@ -778,7 +785,10 @@ export class AdamantApi extends NodeManager {
    * Returns list of transactions
    */
   async getTransactions(options?: TransactionQuery<TransactionsOptions>) {
-    return this.get<GetTransactionsResponseDto>('transactions', options);
+    return this.get<GetTransactionsResponseDto>(
+      'transactions',
+      transformTransactionQuery(options)
+    );
   }
 
   /**
@@ -790,7 +800,7 @@ export class AdamantApi extends NodeManager {
   ) {
     return this.get<GetTransactionByIdResponseDto>('transactions/get', {
       id,
-      ...options,
+      ...transformTransactionQuery(options),
     });
   }
 
@@ -841,4 +851,4 @@ export class AdamantApi extends NodeManager {
 }
 
 export * from './generated';
-export * from './votes';
+export * from './utils';

--- a/src/api/tests/utils.test.ts
+++ b/src/api/tests/utils.test.ts
@@ -1,0 +1,89 @@
+import {transformTransactionQuery} from '../utils';
+
+describe('transformTransactionQuery', () => {
+  it('should transform `or` and `and` object properties', () => {
+    const transformed = transformTransactionQuery({
+      or: {
+        maxAmount: 50000000,
+        senderPublicKey:
+          '801846655523f5e21f2d454b2f98f70aaf5d3887c806463100a1764a4e7c1457',
+        senderPublicKeys: [
+          '801846655523f5e21f2d454b2f98f70aaf5d3887c806463100a1764a4e7c1457',
+          '4ef885053c630041f57493343d7f6023107c5dc8b8148147e732c93',
+        ],
+      },
+      and: {
+        blockId: '7917597195203393333',
+        fromHeight: 10336065,
+        toHeight: 11,
+        minAmount: 1000000000000001,
+        senderId: 'U15423595369615486571',
+        senderIds: ['U18132012621449491414', 'U15881344309699504778'],
+        recipientId: 'U15423595369615486571',
+        recipientIds: ['U18132012621449491414', 'U15881344309699504778'],
+        recipientPublicKey:
+          '801846655523f5e21f2d454b2f98f70aaf5d3887c806463100a1764a4e7c1457',
+        recipientPublicKeys: [
+          '801846655523f5e21f2d454b2f98f70aaf5d3887c806463100a1764a4e7c1457',
+          '4ef885053c630041f57493343d7f6023107c5dc8b8148147e732c93',
+        ],
+        inId: 'U100739400829575109',
+        type: 2,
+        types: [9, 0],
+        key: 'eth:address',
+        keyIds: ['eth:address', 'doge:address', 'dash:address'],
+      },
+    });
+
+    expect(transformed).toStrictEqual({
+      'or:maxAmount': 50000000,
+      'or:senderPublicKey':
+        '801846655523f5e21f2d454b2f98f70aaf5d3887c806463100a1764a4e7c1457',
+      'or:senderPublicKeys': [
+        '801846655523f5e21f2d454b2f98f70aaf5d3887c806463100a1764a4e7c1457',
+        '4ef885053c630041f57493343d7f6023107c5dc8b8148147e732c93',
+      ],
+      'and:blockId': '7917597195203393333',
+      'and:fromHeight': 10336065,
+      'and:toHeight': 11,
+      'and:minAmount': 1000000000000001,
+      'and:senderId': 'U15423595369615486571',
+      'and:senderIds': ['U18132012621449491414', 'U15881344309699504778'],
+      'and:recipientId': 'U15423595369615486571',
+      'and:recipientIds': ['U18132012621449491414', 'U15881344309699504778'],
+      'and:recipientPublicKey':
+        '801846655523f5e21f2d454b2f98f70aaf5d3887c806463100a1764a4e7c1457',
+      'and:recipientPublicKeys': [
+        '801846655523f5e21f2d454b2f98f70aaf5d3887c806463100a1764a4e7c1457',
+        '4ef885053c630041f57493343d7f6023107c5dc8b8148147e732c93',
+      ],
+      'and:inId': 'U100739400829575109',
+      'and:type': 2,
+      'and:types': [9, 0],
+      'and:key': 'eth:address',
+      'and:keyIds': ['eth:address', 'doge:address', 'dash:address'],
+    });
+  });
+
+  it('should NOT transform object properties other than `or` and `and`', () => {
+    const transformed = transformTransactionQuery({
+      minAmount: 5000,
+      senderId: 'U15423595369615486571',
+      senderIds: ['U18132012621449491414', 'U15881344309699504778'],
+      and: {
+        maxAmount: 6000,
+      },
+      or: {
+        recipientIds: ['U18132012621449491414', 'U15881344309699504778'],
+      },
+    });
+
+    expect(transformed).toStrictEqual({
+      minAmount: 5000,
+      senderId: 'U15423595369615486571',
+      senderIds: ['U18132012621449491414', 'U15881344309699504778'],
+      'and:maxAmount': 6000,
+      'or:recipientIds': ['U18132012621449491414', 'U15881344309699504778'],
+    });
+  });
+});

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,0 +1,42 @@
+import {hasOwnProperty} from '../helpers/utils';
+import {TransactionQuery} from '.';
+
+export type VoteDirection = '+' | '-';
+
+export const parseVote = (vote: string): [string, VoteDirection] => {
+  const name = vote.slice(1);
+  const direction = vote.charAt(0);
+
+  return [name, direction as VoteDirection];
+};
+
+export const transformTransactionQuery = <T extends object>(
+  obj?: TransactionQuery<T>
+) => {
+  if (!obj) {
+    return {};
+  }
+
+  const transformed: Record<string, unknown> = {
+    ...obj,
+  };
+
+  for (const topLevelProp in obj) {
+    if (hasOwnProperty(obj, topLevelProp)) {
+      if (topLevelProp === 'or' || topLevelProp === 'and') {
+        const subProps = obj[topLevelProp];
+
+        for (const subProp in subProps) {
+          if (hasOwnProperty(subProps, subProp)) {
+            const newKey = `${topLevelProp}:${subProp}`;
+            transformed[newKey] = subProps[subProp];
+          }
+        }
+
+        delete transformed[topLevelProp];
+      }
+    }
+  }
+
+  return transformed;
+};

--- a/src/api/votes.ts
+++ b/src/api/votes.ts
@@ -1,8 +1,0 @@
-export type VoteDirection = '+' | '-';
-
-export const parseVote = (vote: string): [string, VoteDirection] => {
-  const name = vote.slice(1);
-  const direction = vote.charAt(0);
-
-  return [name, direction as VoteDirection];
-};

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -1,0 +1,6 @@
+export const hasOwnProperty = <T extends object, K extends PropertyKey>(
+  obj: T,
+  prop: K
+): obj is T & Record<K, unknown> => {
+  return Object.prototype.hasOwnProperty.call(obj, prop);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,14 @@ export * from './helpers/constants';
 export * from './helpers/logger';
 export * from './helpers/wsClient';
 export * from './helpers/keys';
+export {
+  isPassphrase,
+  isAdmAddress,
+  isAdmPublicKey,
+  isAdmVoteForPublicKey,
+  isAdmVoteForAddress,
+  isAdmVoteForDelegateName,
+  validateMessage,
+  isDelegateName,
+  admToSats,
+} from './helpers/validator';


### PR DESCRIPTION
# Changelog

## [2.3.0] - 2024-03-01

### Added

- `transformTransactionQuery` function:

  ```ts
  const transformed = transformTransactionQuery({
    fromHeight: 7585271,
    and: {
      toHeight: 7586280,
    },
    or: {
      senderId: 'U18132012621449491414',
    },
  });

  /**
   * {
   *   and:fromHeight: 7585271,
   *   and:toHeight: 7586280,
   *   or:senderId: 'U18132012621449491414'
   * }
   */
  console.log(transformed);
  ```

### Fixed

- TypeScript: `id` should have `string` type in the methods: `api.getTransaction()`, `api.getQueuedTransaction()`, `api.getUnconfirmedTransaction()`

- Global installation of packages that use `adamant-api` as its dependency

- Transaction query methods:

  ```ts
  const blocks = await api.getTransactions({
    fromHeight: 7585271,
    and: {
      toHeight: 7586280,
    },
    or: {
      senderId: 'U18132012621449491414',
    },
  });
  ```